### PR TITLE
Add code comments documenting dark mode fix

### DIFF
--- a/partials/navbar.html
+++ b/partials/navbar.html
@@ -1,3 +1,4 @@
+<!-- Force light theme to ensure menu visibility in dark mode browsers -->
 <div class="navbar bg-base-100 rounded-t-lg shadow-md" data-theme="light">
   <div class="navbar-start">
     <!-- Mobile hamburger -->
@@ -10,7 +11,7 @@
                 d="M4 6h16M4 12h16M4 18h16" />
         </svg>
       </label>
-      <!-- Mobile menu -->
+      <!-- Mobile menu - force light theme for dark mode visibility -->
       <ul tabindex="0"
           class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52"
           data-theme="light">


### PR DESCRIPTION
## Summary
Add inline comments to explain the dark mode visibility fix implemented in the navbar.

## Changes
- Add comment before main navbar div explaining `data-theme="light"` attribute
- Add comment before mobile menu dropdown explaining `data-theme="light"` attribute
- Documents why the navbar is forced to light theme instead of respecting browser dark mode

## Purpose
Improves code maintainability by making it clear to future developers why the navbar doesn't adapt to browser dark mode preferences. The light theme is intentionally forced to ensure menu items remain visible on dark mode browsers (particularly mobile Safari).

## Testing
- [x] Verified on staging (stage.haleythegreyhound.com)
- [x] Comments display correctly in source
- [x] No functional changes - documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)